### PR TITLE
Add composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
   "config": {
     "platform": {
       "php": "7.3"
+    },
+    "allow-plugins": {
+      "bamarni/composer-bin-plugin": true
     }
   },
   "require": {},

--- a/composer.lock
+++ b/composer.lock
@@ -1,70 +1,72 @@
 {
-  "_readme": [
-    "This file locks the dependencies of your project to a known state",
-    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-    "This file is @generated automatically"
-  ],
-  "content-hash": "08bce8888d90a8cac412ebd890217822",
-  "packages": [],
-  "packages-dev": [
-    {
-      "name": "bamarni/composer-bin-plugin",
-      "version": "1.4.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/bamarni/composer-bin-plugin.git",
-        "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-        "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-        "shasum": ""
-      },
-      "require": {
-        "composer-plugin-api": "^1.0 || ^2.0",
-        "php": "^5.5.9 || ^7.0 || ^8.0"
-      },
-      "require-dev": {
-        "composer/composer": "^1.0 || ^2.0",
-        "symfony/console": "^2.5 || ^3.0 || ^4.0"
-      },
-      "type": "composer-plugin",
-      "extra": {
-        "class": "Bamarni\\Composer\\Bin\\Plugin"
-      },
-      "autoload": {
-        "psr-4": {
-          "Bamarni\\Composer\\Bin\\": "src"
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "89f762d440f6b307a4a47830746d0d95",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "bamarni/composer-bin-plugin",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bamarni/composer-bin-plugin.git",
+                "reference": "f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e",
+                "reference": "f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^5.5.9 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0 || ^2.0",
+                "symfony/console": "^2.5 || ^3.0 || ^4.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Bamarni\\Composer\\Bin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Bamarni\\Composer\\Bin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "No conflicts for your bin dependencies",
+            "keywords": [
+                "composer",
+                "conflict",
+                "dependency",
+                "executable",
+                "isolation",
+                "tool"
+            ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.4.2"
+            },
+            "time": "2022-02-16T16:23:46+00:00"
         }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": ["MIT"],
-      "description": "No conflicts for your bin dependencies",
-      "keywords": [
-        "composer",
-        "conflict",
-        "dependency",
-        "executable",
-        "isolation",
-        "tool"
-      ],
-      "support": {
-        "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-        "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
-      },
-      "time": "2020-05-03T08:27:20+00:00"
-    }
-  ],
-  "aliases": [],
-  "minimum-stability": "stable",
-  "stability-flags": [],
-  "prefer-stable": false,
-  "prefer-lowest": false,
-  "platform": [],
-  "platform-dev": [],
-  "platform-overrides": {
-    "php": "7.3"
-  },
-  "plugin-api-version": "2.1.0"
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3"
+    },
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### Description
This PR commits the `allow-plugins` section for `composer.json` so that it is there for anyone who updates to composer `2.2`.

### Related
Part of https://github.com/owncloud/QA/issues/723

Note: This PR is created with a script. If there is any unexpected case in it, I will update manually.
