### PR TITLE
Bump phpstan version to 1.9

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,3 @@
 parameters:
-  autoload_directories:
-    - lib
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "phpstan/phpstan": "^0.12"
+    "phpstan/phpstan": "^1.9"
   }
 }


### PR DESCRIPTION
### Description
- use the latest phpstan, which is 1.9.* series

### Related issue
- https://github.com/owncloud/QA/issues/777