### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/CheckActiveUsers.php
+++ b/lib/Command/CheckActiveUsers.php
@@ -87,7 +87,7 @@ class CheckActiveUsers extends Command {
 			->setDescription('Check if the number of allowed users is exceeded and disables those who are not allowed to be used');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->prepare();
 
 		$licensedUsers = $this->getLicensedUsers();


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.